### PR TITLE
deployment/deployment.yaml: Change deployment apiversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,15 @@ kube-system   Active    18h
 3. Deploy an app in Kubernetes cluster, take `sleep` app as an example
 ```
 $ cat <<EOF | kubectl create -f -
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sleep
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: sleep
   template:
     metadata:
       annotations:

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: perf-sidecar-injector-webhook-deployment
@@ -6,6 +6,9 @@ metadata:
     app: perf-sidecar-injector
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: perf-sidecar-injector
   template:
     metadata:
       labels:


### PR DESCRIPTION
Kubernetes old APIs deprecated from v1.16 and deployment
in the extensions/v1beta1, apps/v1beta1
and apps/v1beta2 API versions is no longer served.
Hence, we are failing to deploy current perf-sidecar injector.
This patch change apiVersion from 'extensions/v1beta1' to
'apps/v1' for both deployment.yaml and README file.

Signed-off-by: Kajol Jain <kjain@linux.ibm.com>